### PR TITLE
Add: Autosave plugin that automatically saves opened files if Enki loose focus

### DIFF
--- a/enki/plugins/autosave.py
+++ b/enki/plugins/autosave.py
@@ -2,9 +2,10 @@
 autosave --- saves all files if enki loses focus
 =============================================================
 """
-import inspect
+import os
 
-from PyQt5.QtWidgets import QApplication, QWidget, QCheckBox, QVBoxLayout, QSpacerItem, QSizePolicy, QLabel
+from PyQt5.QtWidgets import (QApplication, QWidget, QCheckBox, QVBoxLayout,
+                             QSpacerItem, QSizePolicy, QLabel)
 
 from enki.core.core import core
 from enki.core.uisettings import CheckableOption
@@ -12,6 +13,9 @@ from enki.core.uisettings import CheckableOption
 # DONE Setting page
 # DONE checkbox if autosave is activated,
 # DONE Cleanup code (Terminate plugin, etc.)
+# DONE Save only if file is changed
+# DONE Save only if file is writable, else warn the user.
+
 
 class SettingsPage(QWidget):
     """Settings page for Autosave plugi"""
@@ -26,7 +30,10 @@ class SettingsPage(QWidget):
         self._layout = QVBoxLayout(self)
         self._layout.addWidget(self._label)
         self._layout.addWidget(self.checkbox)
-        self._layout.addSpacerItem(QSpacerItem(0, 0, QSizePolicy.MinimumExpanding, QSizePolicy.MinimumExpanding))
+        self._layout.addSpacerItem(QSpacerItem(0, 0,
+                                               QSizePolicy.MinimumExpanding,
+                                               QSizePolicy.MinimumExpanding))
+
 
 class Plugin:
     """Plugin interface implementation
@@ -45,15 +52,17 @@ class Plugin:
 
         self._checkSettings()
 
-        core.uiSettingsManager().aboutToExecute.connect(self._onSettingsDialogAboutToExecute)
+        core.uiSettingsManager().aboutToExecute.connect(
+            self._onSettingsDialogAboutToExecute)
 
     def terminate(self):
         """clean up"""
-        core.uiSettingsManager().aboutToExecute.disconnect(self._onSettingsDialogAboutToExecute)
+        core.uiSettingsManager().aboutToExecute.disconnect(
+            self._onSettingsDialogAboutToExecute)
 
     def _onFocusChanged(self, newWindow):
         """Tests if no window is focused"""
-        if newWindow == None and self._isAutoSaveActive():
+        if newWindow is None and self._isAutoSaveActive():
             self._saveFiles()
 
     def _onClose(self, qobject):
@@ -63,7 +72,13 @@ class Plugin:
     def _saveFiles(self):
         """Saves all open files"""
         for document in core.workspace().documents():
-            document.saveFile()
+            if document.qutepart.document().isModified():
+                if not os.access(document.filePath(), os.W_OK):
+                    core.mainWindow().appendMessage(
+                        "Can not save file '%s', because it is not writable!" %
+                        document.filePath(), 4000)
+                else:
+                    document.saveFile()
 
     def _onSettingsDialogAboutToExecute(self, dialog):
         """UI settings dialogue is about to execute.
@@ -73,13 +88,15 @@ class Plugin:
         dialog.appendPage(u"Autosave", page)
 
         # Options
-        dialog.appendOption(CheckableOption(dialog, core.config(), "Autosave/Active", page.checkbox))
+        dialog.appendOption(CheckableOption(dialog, core.config(),
+                                            "Autosave/Active",
+                                            page.checkbox))
 
     def _checkSettings(self):
         """Check if settings are present in the core configuration file,
         else create and return them.
         """
-        if not "Autosave" in core.config():
+        if "Autosave" not in core.config():
             core.config()["Autosave"] = {}
             core.config()["Autosave"]["Active"] = False
         return core.config()["Autosave"]["Active"]

--- a/enki/plugins/autosave.py
+++ b/enki/plugins/autosave.py
@@ -19,7 +19,7 @@ class SettingsPage(QWidget):
         QWidget.__init__(self, parent)
         text = """
             <h2>Autosave</h2>
-            <p> The Autosave plugin saves your files, if Enki looses focus or is closed.</p>
+            <p> The Autosave plugin saves your files, if Enki looses focus.</p>
             <p></p>"""
         self._label = QLabel(text, self)
         self.checkbox = QCheckBox('Enable Autosave')
@@ -39,6 +39,10 @@ class Plugin:
         """Connect to QApplication OnFocusChanged event"""
         self._qapplication = QApplication.instance()
         self._qapplication.focusWindowChanged.connect(self._onFocusChanged)
+
+        self._qmainwindow = core.mainWindow()
+        self._qmainwindow.destroyed.connect(self._onClose)
+
         self._checkSettings()
 
         core.uiSettingsManager().aboutToExecute.connect(self._onSettingsDialogAboutToExecute)
@@ -51,6 +55,10 @@ class Plugin:
         """Tests if no window is focused"""
         if newWindow == None and self._isAutoSaveActive():
             self._saveFiles()
+
+    def _onClose(self, qobject):
+        """Save files on close of main window"""
+        self._saveFiles()
 
     def _saveFiles(self):
         """Saves all open files"""

--- a/enki/plugins/autosave.py
+++ b/enki/plugins/autosave.py
@@ -1,0 +1,40 @@
+"""
+autosave --- saves all files if enki loses focus
+=============================================================
+"""
+import inspect
+
+from PyQt5.QtWidgets import QApplication
+
+from enki.core.core import core
+
+# TODO Setting page
+# TODO chechbox if autosave is activated
+# TODO checkbox if current file or all files should be saved
+
+class Plugin:
+    """Plugin interface implementation
+
+    The plugin add a focus lost event,
+    get all opened files and save them.
+    """
+
+    def __init__(self):
+        """Connect to QApplication OnFocusChanged event"""
+        self._qapplication = QApplication.instance()
+        self._qapplication.focusWindowChanged.connect(self._onFocusChanged)
+
+    def terminate(self):
+        pass
+
+    def _onFocusChanged(self, newWindow):
+        """Tests if no window is focused"""
+        print("OnFocusChanged")
+        if newWindow == None:
+            print("Save file")
+            self._saveFiles()
+
+    def _saveFiles(self):
+        """Saves all open files"""
+        for document in core.workspace().documents():
+            document.saveFile()

--- a/enki/plugins/autosave.py
+++ b/enki/plugins/autosave.py
@@ -4,37 +4,78 @@ autosave --- saves all files if enki loses focus
 """
 import inspect
 
-from PyQt5.QtWidgets import QApplication
+from PyQt5.QtWidgets import QApplication, QWidget, QCheckBox, QVBoxLayout, QSpacerItem, QSizePolicy, QLabel
 
 from enki.core.core import core
+from enki.core.uisettings import CheckableOption
 
-# TODO Setting page
-# TODO chechbox if autosave is activated
-# TODO checkbox if current file or all files should be saved
+# DONE Setting page
+# DONE checkbox if autosave is activated,
+# DONE Cleanup code (Terminate plugin, etc.)
+
+class SettingsPage(QWidget):
+    """Settings page for Autosave plugi"""
+    def __init__(self, parent):
+        QWidget.__init__(self, parent)
+        text = """
+            <h2>Autosave</h2>
+            <p> The Autosave plugin saves your files, if Enki looses focus or is closed.</p>
+            <p></p>"""
+        self._label = QLabel(text, self)
+        self.checkbox = QCheckBox('Enable Autosave')
+        self._layout = QVBoxLayout(self)
+        self._layout.addWidget(self._label)
+        self._layout.addWidget(self.checkbox)
+        self._layout.addSpacerItem(QSpacerItem(0, 0, QSizePolicy.MinimumExpanding, QSizePolicy.MinimumExpanding))
 
 class Plugin:
     """Plugin interface implementation
 
-    The plugin add a focus lost event,
-    get all opened files and save them.
+    The plugin looks for focusWindowChanged event, get all opened files
+    and saves them.
     """
 
     def __init__(self):
         """Connect to QApplication OnFocusChanged event"""
         self._qapplication = QApplication.instance()
         self._qapplication.focusWindowChanged.connect(self._onFocusChanged)
+        self._checkSettings()
+
+        core.uiSettingsManager().aboutToExecute.connect(self._onSettingsDialogAboutToExecute)
 
     def terminate(self):
-        pass
+        """clean up"""
+        core.uiSettingsManager().aboutToExecute.disconnect(self._onSettingsDialogAboutToExecute)
 
     def _onFocusChanged(self, newWindow):
         """Tests if no window is focused"""
-        print("OnFocusChanged")
-        if newWindow == None:
-            print("Save file")
+        if newWindow == None and self._isAutoSaveActive():
             self._saveFiles()
 
     def _saveFiles(self):
         """Saves all open files"""
         for document in core.workspace().documents():
             document.saveFile()
+
+    def _onSettingsDialogAboutToExecute(self, dialog):
+        """UI settings dialogue is about to execute.
+        Add own options
+        """
+        page = SettingsPage(dialog)
+        dialog.appendPage(u"Autosave", page)
+
+        # Options
+        dialog.appendOption(CheckableOption(dialog, core.config(), "Autosave/Active", page.checkbox))
+
+    def _checkSettings(self):
+        """Check if settings are present in the core configuration file,
+        else create and return them.
+        """
+        if not "Autosave" in core.config():
+            core.config()["Autosave"] = {}
+            core.config()["Autosave"]["Active"] = False
+        return core.config()["Autosave"]["Active"]
+
+    def _isAutoSaveActive(self):
+        """Return if autosave is enabled"""
+        return core.config()["Autosave"]["Active"]


### PR DESCRIPTION
I created an autosave plugin that automatically saves opened files if Enki loose focus. It connects to the `focusWindowChanged` event and saves the files if the focused window is `None`.

The plugin in is deactivated by default.

Hope it helps.