### PR TITLE
Remove docutils and regex imports from run_all.py test runner

### DIFF
--- a/tests/run_all.py
+++ b/tests/run_all.py
@@ -4,7 +4,6 @@ import sys
 
 # Import just to check that dependencies are installed
 import markdown  # noqa: F401
-import regex     # noqa: F401
 
 if __name__ == "__main__":
     # Look for all tests. Using test_* instead of test_*.py finds modules (test_syntax and test_indenter).

--- a/tests/run_all.py
+++ b/tests/run_all.py
@@ -4,7 +4,6 @@ import sys
 
 # Import just to check that dependencies are installed
 import markdown  # noqa: F401
-import docutils  # noqa: F401
 import regex     # noqa: F401
 
 if __name__ == "__main__":


### PR DESCRIPTION
Sphinx and docutils, and regex are optional from 2433dfa1e706.
Lets people skip tests for features that they don't use.

See also https://github.com/andreikop/enki/issues/449#issuecomment-413744509