### PR TITLE
Fix print of action list on exception after 2to3

### DIFF
--- a/enki/core/actionmanager.py
+++ b/enki/core/actionmanager.py
@@ -77,7 +77,7 @@ class ActionManager(QObject):
     def terminate(self):
         if self._pathToAction:
             assert 0, 'ActionManager: you have to delete all actions before destroying actions model. ' + \
-                      'Existing actions: ' + str(iter(self._pathToAction.keys()))
+                      'Existing actions: ' + ', '.join(self._pathToAction.keys())
 
     def action(self, path):
         """Get action by its path. i.e.


### PR DESCRIPTION
Fixes `AssertionError: ActionManager: you have to delete all actions before destroying
actions model. Existing actions: <dict_keyiterator object at 0x7f8512277598>`.

https://travis-ci.org/andreikop/enki/jobs/419067875#L845

The bug was introduced by 2to3 in 66fd108f8502. Other code parts can be affected.