### PR TITLE
README.md Fix running from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ Don't forget to send a bug report if you are having some problems
 
 
 ## Running from the source tree
-    python3 bin/enki
+
+    python3 enki
 
 
 ## Releasing new version


### PR DESCRIPTION
No `bin/enki` since 3b82a7c1e18d