### PR TITLE
README.md Fix run from source command (fixes #457)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Don't forget to send a bug report if you are having some problems
 
 ## Running from the source tree
 
-    python3 enki
+    python3 -m enki
 
 
 ## Releasing new version


### PR DESCRIPTION
`python3 enki` correctly detects and runs `enki/__main__.py`
but doesn't add `enki` to `sys.path`.