### PR TITLE
Load QT_VERSION_STR from QtCore rather than Qt.

### DIFF
--- a/enki/plugins/helpmenu/__init__.py
+++ b/enki/plugins/helpmenu/__init__.py
@@ -8,8 +8,7 @@ About dialogue and *Help* menu items
 import os.path
 
 
-from PyQt5 import Qt
-from PyQt5.QtCore import QObject
+from PyQt5.QtCore import QObject, QT_VERSION_STR
 from PyQt5.QtWidgets import QApplication, QDialog
 from PyQt5.QtGui import QIcon
 from PyQt5 import uic
@@ -65,7 +64,7 @@ class UIAbout(QDialog):
         qpartParser = 'binary' if qutepart.binaryParserAvailable else 'Python'
         qpartVersion = '{} (with {} parser)'.format(qpartNumbers, qpartParser)
         self.lVersion.setText(self.tr("Version %s\n Qutepart %s\n Qt %s") %
-                              (PACKAGE_VERSION, qpartVersion, Qt.QT_VERSION_STR))
+                              (PACKAGE_VERSION, qpartVersion, QT_VERSION_STR))
 
         tabs = {'about': self.wLogo,
                 'help': self.tbHelp,


### PR DESCRIPTION
Currently I can't run enki on Windows 8 due to the dreaded `QtBluetooth` error which is caused by `from PyQt5 import Qt` implicitly calling `from PyQt5 import QtBluetooth` which is unsupported on older windows machines.

Full details are in the commit message...

And I see you have a changelog which I haven't yet touched, would you like me to put a line or two in there?
