### PR TITLE
Fix crash message when changing the EOL

### DIFF
--- a/enki/plugins/editortoolbar/editortoolbar.py
+++ b/enki/plugins/editortoolbar/editortoolbar.py
@@ -141,7 +141,7 @@ class EolIndicatorAndSwitcher(QToolButton):
         document = core.workspace().currentDocument()
         document.qutepart.eol = newEol
         document.qutepart.document().setModified(True)
-        self._setEolMode(document.qutepart.eol)
+        self._setEolMode(None, document.qutepart.eol)
 
     def _setEolMode(self, document, mode):
         """Change EOL mode on GUI


### PR DESCRIPTION
When changing the file's EOL by the GUI, the following crash message appears:

> Traceback (most recent call last):
>
>  File "/usr/lib/python3.8/site-packages/enki/plugins/editortoolbar/editortoolbar.py", line 144, in _onEolActionTriggered
>    self._setEolMode(document.qutepart.eol)
>TypeError: _setEolMode() missing 1 required positional argument: 'mode'