### PR TITLE
Also support Markdown v3.0

### DIFF
--- a/enki/plugins/preview/preview.py
+++ b/enki/plugins/preview/preview.py
@@ -116,14 +116,13 @@ def _convertMarkdown(text):
             """
             DEL_RE = r'(~~)(.*?)~~'
 
-            if markdown_version == 2:
-                def extendMarkdown(self, md, md_globals):
+            def extendMarkdown(self, md, md_globals):
+                if markdown_version == 2:
                     # Create the del pattern
                     delTag = markdown.inlinepatterns.SimpleTagPattern(self.DEL_RE, 'del')
                     # Insert del pattern into markdown parser
                     md.inlinePatterns.add('del', delTag, '>not_strong')
-            else:
-                def extendMarkdown(self, md, md_globals):
+                else:
                      # Create the del pattern
                      del_pattern = Pattern(self.DEL_RE, 'del')
                      # Insert del pattern into markdown parser

--- a/enki/plugins/preview/preview.py
+++ b/enki/plugins/preview/preview.py
@@ -104,8 +104,11 @@ def _convertMarkdown(text):
     extensions = ['fenced_code', 'nl2br', 'tables', 'enki.plugins.preview.mdx_math']
 
     # version 2.0 supports only extension names, not instances
-    if markdown.version_info[0] > 2 or \
-       (markdown.version_info[0] == 2 and markdown.version_info[1] > 0):
+    # version 3.0 moves version_info to __version_info__
+    markdown_version = markdown.version_info[0] \
+    if "version_info" in dir(markdown) else markdown.__version_info__[0]
+    if markdown_version > 2 or \
+       (markdown_version == 2 and markdown.version_info[1] > 0):
 
         class _StrikeThroughExtension(markdown.Extension):
             """http://achinghead.com/python-markdown-adding-insert-delete.html
@@ -113,15 +116,23 @@ def _convertMarkdown(text):
             """
             DEL_RE = r'(~~)(.*?)~~'
 
-            def extendMarkdown(self, md, md_globals):
-                # Create the del pattern
-                delTag = markdown.inlinepatterns.SimpleTagPattern(self.DEL_RE, 'del')
-                # Insert del pattern into markdown parser
-                md.inlinePatterns.add('del', delTag, '>not_strong')
+            if markdown_version == 2:
+                def extendMarkdown(self, md, md_globals):
+                    # Create the del pattern
+                    delTag = markdown.inlinepatterns.SimpleTagPattern(self.DEL_RE, 'del')
+                    # Insert del pattern into markdown parser
+                    md.inlinePatterns.add('del', delTag, '>not_strong')
+            else:
+                def extendMarkdown(self, md, md_globals):
+                     # Create the del pattern
+                     del_pattern = Pattern(self.DEL_RE, 'del')
+                     # Insert del pattern into markdown parser
+                     md.inlinePatterns.register(del_pattern, 'del', 123)
 
         extensions.append(_StrikeThroughExtension())
-
-    return markdown.markdown(text, extensions)
+    if markdown_version == 2:
+        return markdown.markdown(text, extensions)
+    return markdown.markdown(text, globals=extensions)
 
 
 def _convertReST(text):


### PR DESCRIPTION
This fixes errors with Markdown version 3 from 
  Bug 2260075: enki: editing markdown: AttributeError: module 'markdown' has no attribute 'version_info'. (patch) (17 days old)
    https://bugzilla.redhat.com/show_bug.cgi?id=2260075
 
 This pull request is intended to be compatible with both markdown 2.0 and 3.0 using if statements, and only modifies one file.