### PR TITLE
Support markdown 3.7, fix AttributeError: module 'markdown' has no attribute 'version_info'

### DIFF
--- a/enki/plugins/preview/mdx_math.py
+++ b/enki/plugins/preview/mdx_math.py
@@ -22,7 +22,7 @@ class MathExtension(markdown.extensions.Extension):
         }
         super(MathExtension, self).__init__(*args, **kwargs)
 
-    def extendMarkdown(self, md, md_globals):
+    def extendMarkdown(self, md, md_globals=[]):
         def handle_match_inline(m):
             node = markdown.util.etree.Element('script')
             node.set('type', 'math/tex')
@@ -49,12 +49,28 @@ class MathExtension(markdown.extensions.Extension):
         )
         if not self.getConfig('enable_dollar_delimiter'):
             inlinemathpatterns = inlinemathpatterns[1:]
-        for i, pattern in enumerate(inlinemathpatterns):
-            pattern.handleMatch = handle_match_inline
-            md.inlinePatterns.add('math-inline-%d' % i, pattern, '<escape')
-        for i, pattern in enumerate(mathpatterns):
-            pattern.handleMatch = handle_match
-            md.inlinePatterns.add('math-%d' % i, pattern, '<escape')
+
+        # version 3.0 moves version_info to __version_info__
+        markdown_version = markdown.version_info[0]\
+            if "version_info" in dir(markdown) \
+            else markdown.__version_info__[0]
+
+        if markdown_version == 2:
+            for i, pattern in enumerate(inlinemathpatterns):
+                pattern.handleMatch = handle_match_inline
+                md.inlinePatterns.add('math-inline-%d' % i, pattern, '<escape')
+            for i, pattern in enumerate(mathpatterns):
+                pattern.handleMatch = handle_match
+                md.inlinePatterns.add('math-%d' % i, pattern, '<escape')
+        else:
+            for i, pattern in enumerate(inlinemathpatterns):
+                pattern.handleMatch = handle_match_inline
+                md.inlinePatterns.register(pattern, 'math-inline-%d' % i, 100)
+
+            for i, pattern in enumerate(mathpatterns):
+                pattern.handleMatch = handle_match
+                md.inlinePatterns.register(pattern, 'math-%d' % i, 100)
+
 
 
 def makeExtension(*args, **kwargs):

--- a/enki/plugins/preview/preview.py
+++ b/enki/plugins/preview/preview.py
@@ -104,8 +104,12 @@ def _convertMarkdown(text):
     extensions = ['fenced_code', 'nl2br', 'tables', 'enki.plugins.preview.mdx_math']
 
     # version 2.0 supports only extension names, not instances
-    if markdown.version_info[0] > 2 or \
-       (markdown.version_info[0] == 2 and markdown.version_info[1] > 0):
+    # version 3.0 moves version_info to __version_info__
+    markdown_version = markdown.version_info[0]\
+        if "version_info" in dir(markdown) \
+        else markdown.__version_info__[0]
+
+    if markdown_version == 2 and markdown.version_info[1] > 0:
 
         class _StrikeThroughExtension(markdown.Extension):
             """http://achinghead.com/python-markdown-adding-insert-delete.html
@@ -113,15 +117,26 @@ def _convertMarkdown(text):
             """
             DEL_RE = r'(~~)(.*?)~~'
 
-            def extendMarkdown(self, md, md_globals):
+            def extendMarkdown(self, md):
                 # Create the del pattern
                 delTag = markdown.inlinepatterns.SimpleTagPattern(self.DEL_RE, 'del')
                 # Insert del pattern into markdown parser
-                md.inlinePatterns.add('del', delTag, '>not_strong')
+                markdown.inlinepatterns.add('del', delTag, '>not_strong')
+    elif markdown_version == 3:
+        class _StrikeThroughExtension(markdown.Extension):
+            """A Markdown extension to add strikethrough support using the <del> tag."""
+            DEL_RE = r'(~~)(.*?)~~'  # Simplified regex pattern
+
+            def extendMarkdown(self, md):
+                STRIKETHROUGH_PATTERN = r"(~~)(.*?)~~"
+                md.inlinePatterns.register(markdown.inlinepatterns.SimpleTagInlineProcessor(STRIKETHROUGH_PATTERN, 'del'), 'strikethrough', 175)
+
+        def strikethrough(text):
+            return markdown.markdown(text, extensions=[_StrikethroughExtension()])
 
         extensions.append(_StrikeThroughExtension())
 
-    return markdown.markdown(text, extensions)
+    return markdown.markdown(text, extensions=extensions)
 
 
 def _convertReST(text):


### PR DESCRIPTION
This not only stops the errors, but actually works this time!  

- Supports markdown 3.7
- Inserts ~~strikethru~~
- Inserts <del&gt; element into HTML preview like it's supposed to.

I tried also making it work with markdown 2.0 because the code tests for it but...

- Enki wasn't working with Markdown 2.0 BEFORE this PR.

Easiest way to prove it:
```
git checkout f32dc18e
python setup.py install
python -m enki
.micromamba/envs/enki_md2/lib/python3.7/site-packages/docutils-0.21.2-py3.7.egg/docutils/utils/math/latex2mathml.py", line 311, in <module>
    'dbinom': layout_styles['displaystyle'] | {'linethickness': 0},
TypeError: unsupported operand type(s) for |: 'dict' and 'dict'
```
According to https://github.com/run-llama/llama_index/issues/10101 this TypeErrror is due to the use of the "|" operator to merge dictionaries. This feature was introduced in Python 3.9, so was is not available for Python 3.7.

- [at least] Python 3.9 is required to run Enki
- Python 3.7 is the last version to support markdown 2.0
- Hence, markdown 2.0 has not been working for some time.
